### PR TITLE
EduID UTF-8 Error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>connector-eduid</artifactId>
-    <version>1.0.0.0</version>
+    <version>1.0.0.1</version>
     <packaging>jar</packaging>
 
     <name>SWITCH edu-ID Affiliation Connector</name>

--- a/src/main/java/com/evolveum/polygon/connector/eduid/EduIdConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/eduid/EduIdConnector.java
@@ -175,7 +175,7 @@ public class EduIdConnector extends AbstractRestConnector<EduIdConfiguration> im
         LOG.ok("response: {0}", response);
         processEduIdResponseErrors(response);
 
-        String result = EntityUtils.toString(response.getEntity());
+        String result = EntityUtils.toString(response.getEntity(), "UTF-8");
         LOG.ok("response body: {0}", result);
         closeResponse(response);
         return new JSONObject(result);
@@ -196,7 +196,7 @@ public class EduIdConnector extends AbstractRestConnector<EduIdConfiguration> im
             closeResponse(response);
             return null;
         }
-        String result = EntityUtils.toString(response.getEntity());
+        String result = EntityUtils.toString(response.getEntity(), "UTF-8");
         LOG.ok("response body: {0}", result);
         closeResponse(response);
         return new JSONObject(result);
@@ -230,7 +230,7 @@ public class EduIdConnector extends AbstractRestConnector<EduIdConfiguration> im
         LOG.ok("response: {0}", response);
         processEduIdResponseErrors(response);
 
-        String result = EntityUtils.toString(response.getEntity());
+        String result = EntityUtils.toString(response.getEntity(), "UTF-8");
         LOG.ok("response body: {0}", result);
         closeResponse(response);
         return new JSONArray(result);
@@ -241,7 +241,7 @@ public class EduIdConnector extends AbstractRestConnector<EduIdConfiguration> im
         if (statusCode == 409) {
             String result = null;
             try {
-                result = EntityUtils.toString(response.getEntity());
+                result = EntityUtils.toString(response.getEntity(), "UTF-8");
                 LOG.ok("Result body: {0}", result);
             } catch (IOException e) {
                 throw new ConnectorIOException("Error when trying to get response entity: "+response, e);
@@ -266,7 +266,7 @@ public class EduIdConnector extends AbstractRestConnector<EduIdConfiguration> im
         } else if (statusCode == 400) {
             String result = null;
             try {
-                result = EntityUtils.toString(response.getEntity());
+                result = EntityUtils.toString(response.getEntity(), "UTF-8");
                 LOG.ok("Result body: {0}", result);
             } catch (IOException e) {
                 throw new ConnectorIOException("Error when trying to get response entity: "+response, e);


### PR DESCRIPTION
Switch EduID API stopped sending "charset=UTF-8" in the http header.
Now the Connector encodes in ISO-8859-1 because there is no information.
So everytime someone has a special character in their name there's some problems.

I solved it by  adding "UTF-8" after "response.getEntity()" in the result variable.

Tested in our LAB Environment and it worked.